### PR TITLE
Separated error term from private key

### DIFF
--- a/RlweConstants.java
+++ b/RlweConstants.java
@@ -19,6 +19,9 @@ class Constants {
   protected static final int Q_TIMES_16 = 196624;
 
   protected static final int numRecDataBytes = 256;
+
+  protected static final byte FOURIER = 0;
+  protected static final byte ORDINARY = 1;
   
   protected static final Felm[] OMEGA = new Felm[] {
     new Felm (1),     new Felm (49),    new Felm (2401),  new Felm (7048),  new Felm (1260),

--- a/RlweKeyExchange.java
+++ b/RlweKeyExchange.java
@@ -65,17 +65,6 @@ class RlweKeyExchange {
   }
  
  
-  /* 
-   * At a high level, 4 coefficients are used per bit of shared key produced. Computing 
-   * reconciliation data involves finding the closest lattice vector to those 4 coefficients (as a
-   * vector) and computing the discretized difference between those coefficients and the closest 
-   * lattice vector. This discretized difference is the reconciliation data vector, r. It is assumed 
-   * that translating a lattice point by r will move it closer to the correct lattice point. The
-   * function helpRec uses an algorithm for the closest vector problem to find r, and the function 
-   * rec computes reconciliation using r. The reconciliation data is 2 bits per coefficient so this
-   * is compressed before being sent to reduce bandwidth.
-   */
-
   private byte[] helpRec (RingElt v) {
     int i, j, k, x, rbit, norm;
     int[] v0 = new int[4];

--- a/RlweTest.java
+++ b/RlweTest.java
@@ -33,14 +33,12 @@ class RlweTest {
       /*
       System.out.println ("Initiator private key: ");
       System.out.println ("\t s = " + keysI.getPrivateKey().getS());
-      System.out.println ("\t e = " + keysI.getPrivateKey().getE() + "\n");
       
       System.out.println ("Initiator public key: ");
       System.out.println ("\t k = " + keysI.getPublicKey().getKey() + "\n");
       
       System.out.println ("Responder private key: ");
       System.out.println ("\t s = " + keysR.getPrivateKey().getS());
-      System.out.println ("\t e = " + keysR.getPrivateKey().getE() + "\n");
       
       System.out.println ("Responder public key: ");
       System.out.println ("\t k = " + keysR.getPublicKey().getKey() + "\n");


### PR DESCRIPTION
In RLWE, a public/private key pair is really a public key/private key/error term triple. Originally, the error term was included as a variable in the private key object, but this has been removed. Once the public key has been established the error term is no longer needed so the error term is created during generation of the public key and discarded. The only detriment is that it is impossible to recreate the same public key from a given private key.